### PR TITLE
Updated sync logic

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,184 @@
+# Instructions for Building a Singer Tap/Target
+
+This document provides guidance for implementing a high-quality Singer Tap (or Target) in compliance with the Singer specification and community best practices. Use it in conjunction with GitHub Copilot or your preferred IDE.
+
+---
+
+## 1. Rate Limiting
+
+- Respect API rate limits (e.g., daily quotas or per-second limits).
+- For short-term rate limits, detect HTTP 429 or similar errors and implement retries with sleep/delay.
+- Use Singer’s built-in rate-limiting utilities where available.
+
+
+## 2. Memory Efficiency
+
+- Minimize RAM usage by streaming data.
+Example: Use generators or iterators instead of loading entire datasets into memory.
+
+
+## 3. Consistent Date Handling
+
+- Use RFC 3339 format (including time zone offset). UTC (Z) is preferred.
+Examples:
+Good: 2017-01-01T00:00:00Z, 2017-01-01T00:00:00-05:00
+Bad: 2017-01-01 00:00:00
+Use pytz for timezone-aware conversions.
+
+
+## 4. Logging & Exception Handling
+
+- Log every API request (URL + parameters), omitting sensitive info (e.g., API keys).
+- Log progress updates (e.g., “Starting stream X”).
+- On API errors, log status code and response body.
+
+For fatal errors:
+- Log at CRITICAL or FATAL level.
+- Exit with non-zero status.
+- Omit stack trace for known, user-triggered conditions.
+- Include full trace for unexpected exceptions.
+- For recoverable errors, implement retries with exponential backoff (e.g., using the backoff library).
+
+
+## 5. Module Structure
+
+- Organize code into a proper Python module (directory with __init__.py), not a single script file.
+
+
+## 6. Schema Management
+
+- For static schemas, store them as .json files in a schemas/ directory—not as inline Python dicts.
+Prefer explicit schemas:
+- Avoid additionalProperties: true or vague typing.
+- Use clear field names and types.
+- Set additionalProperties: false when schemas must be strict.
+- Be cautious when tightening schemas in new versions—it may require a major version bump per semantic versioning.
+
+
+## 7. JSON Schema Guidelines
+
+- All files under schemas/*.json must follow the JSON Schema standard.
+- Any fields named created_time, modified_time, ending in _time or ending in _date must use the date-time format.
+- Any fields looks like date-time field, give suggestion to validate the fields should have date-time format.
+- Avoid using additionalProperties at the root level. It's allowed in nested fields only.
+
+Example:
+{
+  "type": "object",
+  "properties": {
+    "created_time": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "last_access_time": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    }
+  }
+}
+
+
+## 8. Validating Bookmarking
+
+We use the singer.bookmarks module to read from and write to the bookmark state file.
+To ensure correctness, always validate the structure of the bookmark state before processing or committing any changes.
+- In abstract.py, we use get_bookmark() and write_bookmark() to manage bookmarks for streams.
+- The write_bookmark() function overrides the one from the singer module to apply custom behavior.
+- Always confirm that the state structure matches the expected format before writing.
+
+Format Example:
+{
+  "bookmarks": {
+    "stream_name": {
+      "replication_key": "2024-01-01T00:00:00Z"
+    }
+  }
+}
+
+
+Optional validation function:
+def is_valid_bookmark_state(state):
+    return isinstance(state, dict) and \
+           "bookmarks" in state and \
+           isinstance(state["bookmarks"], dict)
+
+
+## 9. Code Quality
+
+- Use pylint and aim for zero error-level messages.
+- CI pipelines (e.g., CircleCI) should enforce linting.
+- Fix or explicitly disable warnings when appropriate.
+
+
+## 10. Loop Safety
+
+- **Avoid `while True` loops.** Use explicit conditions instead (e.g., `while has_more_pages`).
+- Every loop must have a clear exit condition that will eventually be satisfied.
+- For pagination loops, ensure there's a termination condition (e.g., no next page, empty results, max iterations).
+- Add safeguards like maximum iteration counts or timeouts for loops that depend on external API responses.
+
+Good example (explicit condition):
+```python
+max_pages = 1000
+current_page = 1
+has_more_pages = True
+
+while has_more_pages and current_page <= max_pages:
+    response = fetch_page(current_page)
+    if not response or not response.get('data'):
+        has_more_pages = False
+        break
+
+    process_data(response['data'])
+
+    next_page = response.get('next_page')
+    if not next_page:
+        has_more_pages = False
+    else:
+        current_page += 1
+```
+
+Bad example (using while True):
+```python
+while True:
+    response = fetch_page()
+    if not response:
+        break  # Avoid this pattern
+    process_data(response)
+```
+
+
+## 11. Record Completeness
+
+- **Never skip records during sync unless absolutely necessary.**
+- If a record encounters an error during transformation or validation, log the error with full context but do not silently skip it.
+- Only skip records if:
+  - They fail schema validation and cannot be processed (log as WARNING or ERROR).
+  - They are explicitly filtered by business logic (e.g., replication key filtering).
+- **Never use `continue` to skip records on errors without logging.**
+
+Good example (log and handle errors):
+```python
+for record in get_records():
+    try:
+        transformed = transformer.transform(record, schema, metadata)
+        write_record(stream_name, transformed)
+        counter.increment()
+    except Exception as e:
+        LOGGER.error(f"Failed to transform record {record.get('id')}: {e}")
+        # Re-raise or handle based on severity
+        raise
+```
+
+Bad example (silently skipping records):
+```python
+for record in get_records():
+    try:
+        transformed = transformer.transform(record, schema, metadata)
+        write_record(stream_name, transformed)
+    except Exception:
+        continue  # Silently skips - BAD!
+```
+
+- For incremental streams, ensure bookmark filtering logic is correct to avoid data loss.
+- If a record must be skipped, document why in the code and log it clearly.

--- a/tap_customerio/client.py
+++ b/tap_customerio/client.py
@@ -63,8 +63,8 @@ class Client:
         pass
 
     def authenticate(self, headers: Dict, params: Dict) -> Tuple[Dict, Dict]:
-        """Authenticates the request with the token"""
-        headers = {'Authorization': 'Bearer {}'.format(self.config['access_token'])}
+        """Authenticates the request with the token, preserving any existing headers."""
+        headers = {**headers, 'Authorization': 'Bearer {}'.format(self.config['access_token'])}
         return headers, params
 
     def make_request(

--- a/tap_customerio/exceptions.py
+++ b/tap_customerio/exceptions.py
@@ -32,8 +32,14 @@ class customerioConflictError(customerioError):
     """class representing 409 status code."""
     pass
 
-class customerioUnprocessableEntityError(customerioBackoffError):
-    """class representing 422 status code."""
+class customerioUnprocessableEntityError(customerioError):
+    """class representing 422 status code.
+
+    422 Unprocessable Entity indicates the request body is syntactically
+    correct but semantically invalid (e.g. a malformed filter expression).
+    This is a deterministic client-side error that will not resolve on retry;
+    retrying with backoff would only waste API quota.
+    """
     pass
 
 class customerioRateLimitError(customerioBackoffError):

--- a/tap_customerio/streams/abstracts.py
+++ b/tap_customerio/streams/abstracts.py
@@ -98,8 +98,15 @@ class BaseStream(ABC):
         """
 
     def get_records(self) -> Iterator:
-        """Interacts with API client and handles pagination."""
-        self.params["page"] = self.page_size
+        """Interacts with API client and handles pagination.
+
+        NOTE for stream authors: this base implementation sends ``limit`` as
+        the page-size query parameter.  If your endpoint uses a different
+        parameter name (e.g. ``per_page``), override ``get_records()`` in
+        your subclass rather than relying on this behaviour.
+        Activities and Customers already override this method entirely.
+        """
+        self.params["limit"] = self.page_size
         pagination_token = None
         has_more_pages = True
 

--- a/tap_customerio/streams/abstracts.py
+++ b/tap_customerio/streams/abstracts.py
@@ -29,7 +29,8 @@ class BaseStream(ABC):
     url_endpoint = ""
     path = ""
     page_size = 1000
-    next_page_key = "next"
+    next_page_key = "next"    # key used to read the next-page cursor from the response
+    next_page_param = None    # param name used to send the cursor in the next request
     headers = {'Accept': 'application/json'}
     children = []
     parent = ""
@@ -99,8 +100,13 @@ class BaseStream(ABC):
     def get_records(self) -> Iterator:
         """Interacts with API client and handles pagination."""
         self.params["page"] = self.page_size
-        next_page = 1  # Start from page 1
-        while next_page:
+        pagination_token = None
+        has_more_pages = True
+
+        while has_more_pages:
+            if pagination_token and self.next_page_param:
+                self.params[self.next_page_param] = pagination_token
+
             response = self.client.make_request(
                 self.http_method,
                 self.url_endpoint,
@@ -109,12 +115,14 @@ class BaseStream(ABC):
                 body=json.dumps(self.data_payload),
                 path=self.path
             )
-            raw_records = response.get(self.data_key, None)
-            if raw_records is None:
-                raw_records = []  # Default to an empty list if None
-            next_page = response.get(self.next_page_key)
-            self.params[self.next_page_key] = next_page
+            raw_records = response.get(self.data_key) or []
+            if not isinstance(raw_records, list):
+                raw_records = [raw_records]
+
             yield from raw_records
+
+            pagination_token = response.get(self.next_page_key) if self.next_page_key else None
+            has_more_pages = bool(pagination_token)
 
     def write_schema(self) -> None:
         """

--- a/tap_customerio/streams/activities.py
+++ b/tap_customerio/streams/activities.py
@@ -12,33 +12,39 @@ class Activities(FullTableStream):
     data_key = "activities"
     path = "activities"
 
-    # The /v1/activities response returns the next-page cursor under the key
-    # "next", but the REQUEST must pass that value as "start" — not "next".
-    # The base-class get_records() uses next_page_key for both reading the
-    # cursor from the response AND as the request parameter name, so we must
-    # override get_records() here to apply the correct parameter mapping.
-    #
-    # Additionally, the base class sets params["page"] = page_size (1000), but
-    # the activities endpoint only recognises "limit" (max 100).
+    # The /v1/activities endpoint uses a cursor-based pagination scheme where:
+    #   - the response carries the next cursor under "next"
+    #   - the request must send that cursor as the "start" parameter
 
-    _LIMIT = 100  # maximum page size accepted by the activities endpoint
+    next_page_key = "next"
+    next_page_param = "start"
+
+    # The activities endpoint only accepts "limit" (max 100).
+    page_size = 100
 
     def get_records(self) -> Iterator:
         """Paginate the activities endpoint using cursor-based pagination.
 
-        Response key: "next"  (cursor for the next page)
-        Request key:  "start" (cursor to begin the next page from)
+        Overrides the base implementation to:
+        - use "limit" instead of "page" as the page-size parameter
+        - guard against a stuck API (live cursor + empty page → stop)
+
+        Response key: ``next_page_key``  = "next"
+        Request key:  ``next_page_param`` = "start"
         """
-        self.params["limit"] = self._LIMIT
-        next_cursor = None  # No cursor on the first request
+        self.params["limit"] = self.page_size
+        pagination_token = None
+        has_more_pages = True
+        page_number = 0
 
-        while True:
-            if next_cursor:
-                self.params["start"] = next_cursor
-            elif "start" in self.params:
-                # Clean up any stale cursor from a previous call
-                del self.params["start"]
+        while has_more_pages:
+            if pagination_token:
+                self.params[self.next_page_param] = pagination_token
+            elif self.next_page_param in self.params:
+                # Remove any stale cursor left over from a previous call
+                del self.params[self.next_page_param]
 
+            page_number += 1
             response = self.client.make_request(
                 self.http_method,
                 self.url_endpoint,
@@ -49,9 +55,12 @@ class Activities(FullTableStream):
             )
 
             raw_records = response.get(self.data_key) or []
-            next_cursor = response.get("next")  # may be None on the last page
+            if not isinstance(raw_records, list):
+                raw_records = [raw_records]
+
             yield from raw_records
 
-            if not next_cursor:
-                break
+            pagination_token = response.get(self.next_page_key)
 
+            # Continue only when the API provides a cursor AND returned records.
+            has_more_pages = bool(pagination_token) and bool(raw_records)

--- a/tap_customerio/streams/activities.py
+++ b/tap_customerio/streams/activities.py
@@ -1,4 +1,8 @@
+import json
+from typing import Iterator
+
 from tap_customerio.streams.abstracts import FullTableStream
+
 
 class Activities(FullTableStream):
     tap_stream_id = "activities"
@@ -7,4 +11,47 @@ class Activities(FullTableStream):
     replication_keys = []
     data_key = "activities"
     path = "activities"
+
+    # The /v1/activities response returns the next-page cursor under the key
+    # "next", but the REQUEST must pass that value as "start" — not "next".
+    # The base-class get_records() uses next_page_key for both reading the
+    # cursor from the response AND as the request parameter name, so we must
+    # override get_records() here to apply the correct parameter mapping.
+    #
+    # Additionally, the base class sets params["page"] = page_size (1000), but
+    # the activities endpoint only recognises "limit" (max 100).
+
+    _LIMIT = 100  # maximum page size accepted by the activities endpoint
+
+    def get_records(self) -> Iterator:
+        """Paginate the activities endpoint using cursor-based pagination.
+
+        Response key: "next"  (cursor for the next page)
+        Request key:  "start" (cursor to begin the next page from)
+        """
+        self.params["limit"] = self._LIMIT
+        next_cursor = None  # No cursor on the first request
+
+        while True:
+            if next_cursor:
+                self.params["start"] = next_cursor
+            elif "start" in self.params:
+                # Clean up any stale cursor from a previous call
+                del self.params["start"]
+
+            response = self.client.make_request(
+                self.http_method,
+                self.url_endpoint,
+                self.params,
+                self.headers,
+                body=json.dumps(self.data_payload),
+                path=self.path,
+            )
+
+            raw_records = response.get(self.data_key) or []
+            next_cursor = response.get("next")  # may be None on the last page
+            yield from raw_records
+
+            if not next_cursor:
+                break
 

--- a/tap_customerio/streams/customers.py
+++ b/tap_customerio/streams/customers.py
@@ -1,4 +1,17 @@
+import json
+from typing import Iterator
+
 from tap_customerio.streams.abstracts import FullTableStream
+
+# Filter that matches every customer (all have a cio_id)
+ALL_CUSTOMERS_FILTER = {
+    "filter": {
+        "and": [{"attribute": {"field": "cio_id", "operator": "exists"}}]
+    }
+}
+# Number of IDs to resolve per POST /customers/attributes call
+ATTRIBUTES_BATCH_SIZE = 100
+
 
 class Customers(FullTableStream):
     tap_stream_id = "customers"
@@ -8,3 +21,56 @@ class Customers(FullTableStream):
     data_key = "customers"
     path = "customers/attributes"
     http_method = "POST"
+
+    def get_records(self) -> Iterator:
+        """
+        The Customer.io API requires a two-step approach to retrieve all customers:
+
+        Step 1 – POST /v1/customers
+            Supply a broad filter and paginate via the `start` cursor parameter to
+            collect all customer IDs.
+
+        Step 2 – POST /v1/customers/attributes
+            Pass the IDs collected in step 1 (in batches) to retrieve full customer
+            attribute records.
+
+        The base-class implementation sends an empty body to
+        POST /v1/customers/attributes, which returns an empty list because the
+        endpoint requires explicit IDs.
+        """
+        list_endpoint = f"{self.client.base_url}/customers"
+        attrs_endpoint = f"{self.client.base_url}/customers/attributes"
+        headers = {**self.headers, "Content-Type": "application/json"}
+
+        list_params = {"limit": self.page_size}
+        start_cursor = None
+
+        while True:
+            if start_cursor:
+                list_params["start"] = start_cursor
+
+            list_response = self.client.make_request(
+                "POST",
+                list_endpoint,
+                list_params,
+                headers,
+                body=json.dumps(ALL_CUSTOMERS_FILTER),
+            )
+
+            ids = list_response.get("ids", [])
+
+            # Fetch full attributes in batches
+            for i in range(0, len(ids), ATTRIBUTES_BATCH_SIZE):
+                batch_ids = ids[i : i + ATTRIBUTES_BATCH_SIZE]
+                attrs_response = self.client.make_request(
+                    "POST",
+                    attrs_endpoint,
+                    {},
+                    headers,
+                    body=json.dumps({"ids": batch_ids}),
+                )
+                yield from attrs_response.get("customers", [])
+
+            start_cursor = list_response.get("next")
+            if not start_cursor:
+                break

--- a/tap_customerio/streams/customers.py
+++ b/tap_customerio/streams/customers.py
@@ -34,9 +34,9 @@ class Customers(FullTableStream):
             Pass the IDs collected in step 1 (in batches) to retrieve full customer
             attribute records.
 
-        The base-class implementation sends an empty body to
-        POST /v1/customers/attributes, which returns an empty list because the
-        endpoint requires explicit IDs.
+        The base-class implementation sends a request body that lacks the required
+        `ids` field (for example, an empty JSON object) to POST /v1/customers/attributes,
+        which returns an empty list because the endpoint requires explicit IDs.
         """
         list_endpoint = f"{self.client.base_url}/customers"
         attrs_endpoint = f"{self.client.base_url}/customers/attributes"

--- a/tap_customerio/streams/customers.py
+++ b/tap_customerio/streams/customers.py
@@ -3,7 +3,18 @@ from typing import Iterator
 
 from tap_customerio.streams.abstracts import FullTableStream
 
-# Filter that matches every customer (all have a cio_id)
+# Filter that matches every *tracked* customer in the workspace.
+#
+# Assumption: ``cio_id`` is assigned to every profile that has been
+# explicitly identified via the Customer.io identify call or an import.
+# Anonymous/untracked profiles (those that have only been observed through
+# page-view events and have never been identified) will NOT have a ``cio_id``
+# set in all workspace configurations and will therefore be excluded from this
+# filter.
+#
+# If your workspace tracks anonymous profiles that should also be exported,
+# replace or extend this filter to suit your requirements, or make the filter
+# configurable via tap config.
 ALL_CUSTOMERS_FILTER = {
     "filter": {
         "and": [{"attribute": {"field": "cio_id", "operator": "exists"}}]

--- a/tap_customerio/streams/customers.py
+++ b/tap_customerio/streams/customers.py
@@ -44,11 +44,14 @@ class Customers(FullTableStream):
 
         list_params = {"limit": self.page_size}
         start_cursor = None
+        has_more_pages = True
+        page_number = 0
 
-        while True:
+        while has_more_pages:
             if start_cursor:
                 list_params["start"] = start_cursor
 
+            page_number += 1
             list_response = self.client.make_request(
                 "POST",
                 list_endpoint,
@@ -57,7 +60,7 @@ class Customers(FullTableStream):
                 body=json.dumps(ALL_CUSTOMERS_FILTER),
             )
 
-            ids = list_response.get("ids", [])
+            ids = list_response.get("ids") or []
 
             # Fetch full attributes in batches
             for i in range(0, len(ids), ATTRIBUTES_BATCH_SIZE):
@@ -69,8 +72,12 @@ class Customers(FullTableStream):
                     headers,
                     body=json.dumps({"ids": batch_ids}),
                 )
-                yield from attrs_response.get("customers", [])
+                customers = attrs_response.get("customers") or []
+                if not isinstance(customers, list):
+                    customers = [customers]
+                yield from customers
 
             start_cursor = list_response.get("next")
-            if not start_cursor:
-                break
+
+            # Continue only when the API provides a cursor AND returned IDs.
+            has_more_pages = bool(start_cursor) and bool(ids)

--- a/tap_customerio/streams/newsletters.py
+++ b/tap_customerio/streams/newsletters.py
@@ -1,6 +1,3 @@
-import json
-from typing import Iterator
-
 from tap_customerio.streams.abstracts import IncrementalStream
 
 class Newsletters(IncrementalStream):
@@ -10,26 +7,5 @@ class Newsletters(IncrementalStream):
     replication_keys = ["updated"]
     data_key = "newsletters"
     path = "newsletters"
-
-    def get_records(self) -> Iterator:
-        next_page = None
-        while True:
-            params = {}
-            if next_page:
-                params["start"] = next_page  # correct param for cursor
-            response = self.client.make_request(
-                self.http_method,
-                self.url_endpoint,
-                params=params,
-                headers=self.headers,
-                body=json.dumps(self.data_payload) if self.data_payload else None,
-                path=self.path
-            )
-
-            raw_records = response.get(self.data_key, []) or []
-            yield from raw_records
-
-            next_page = response.get("next")
-            if not next_page:
-                break
+    next_page_param = "start"
 

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -53,7 +53,7 @@ class TestClient(unittest.TestCase):
         """Set up the client with default configuration."""
         self.client = Client(default_config)
 
-    @parameterized.expand([    
+    @parameterized.expand([
         ["empty value", "", DEFAULT_REQUEST_TIMEOUT],
         ["string value", "12", 12.0],
         ["integer value", 10, 10.0],
@@ -89,9 +89,10 @@ class TestClient(unittest.TestCase):
         ["403 error", 403, MockResponse(403), customerioForbiddenError, "You are missing the following required scopes: read"],
         ["404 error", 404, MockResponse(404), customerioNotFoundError, "The resource you have specified cannot be found."],
         ["409 error", 409, MockResponse(409), customerioConflictError, "The API request cannot be completed because the requested operation would conflict with an existing item."],
+        ["422 error", 422, MockResponse(422), customerioUnprocessableEntityError, "The request content itself is not processable by the server."],
     ])
     def test_make_request_http_failure_without_retry(self, test_name, error_code, mock_response, error, error_message):
-        
+
         with patch.object(self.client._session, "request", return_value=mock_response):
             with self.assertRaises(error) as e:
                 self.client._Client__make_request("GET", "https://api.example.com/resource")
@@ -100,7 +101,6 @@ class TestClient(unittest.TestCase):
         self.assertEqual(str(e.exception), expected_error_message)
 
     @parameterized.expand([
-        ["422 error", 422, MockResponse(422), customerioUnprocessableEntityError, "The request content itself is not processable by the server."],
         ["429 error", 429, MockResponse(429), customerioRateLimitError, "The API rate limit for your organisation/application pairing has been exceeded."],
         ["500 error", 500, MockResponse(500), customerioInternalServerError, "The server encountered an unexpected condition which prevented it from fulfilling the request."],
         ["501 error", 501, MockResponse(501), customerioNotImplementedError, "The server does not support the functionality required to fulfill the request."],
@@ -109,7 +109,7 @@ class TestClient(unittest.TestCase):
     ])
     @patch("time.sleep")
     def test_make_request_http_failure_with_retry(self, test_name, error_code, mock_response, error, error_message, mock_sleep):
-        
+
         with patch.object(self.client._session, "request", return_value=mock_response) as mock_request:
             with self.assertRaises(error) as e:
                 self.client._Client__make_request("GET", "https://api.example.com/resource")
@@ -126,9 +126,9 @@ class TestClient(unittest.TestCase):
     ])
     @patch("time.sleep")
     def test_make_request_other_failure_with_retry(self, test_name, error, mock_sleep):
-        
+
         with patch.object(self.client._session, "request", side_effect=error) as mock_request:
             with self.assertRaises(error) as e:
                 self.client._Client__make_request("GET", "https://api.example.com/resource")
-            
+
             self.assertEqual(mock_request.call_count, 5)

--- a/tests/unittests/test_streams_get_records.py
+++ b/tests/unittests/test_streams_get_records.py
@@ -1,0 +1,323 @@
+"""Unit tests for Activities.get_records() and Customers.get_records().
+
+Covers:
+ - Cursor-based pagination (single and multi-page)
+ - Correct request parameters (limit, start) across pages
+ - Termination conditions (no cursor, empty cursor, empty records)
+ - Infinite-loop guard (empty page returned with a live cursor)
+ - Null-safe handling when API returns null for ids / customers keys
+ - Two-step flow in Customers (list IDs → fetch attributes in batches)
+ - Content-Type header propagation after authenticate() merge fix
+"""
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+from parameterized import parameterized
+
+from tap_customerio.streams.activities import Activities
+from tap_customerio.streams.customers import (
+    ALL_CUSTOMERS_FILTER,
+    Customers,
+)
+
+
+class ConcreteActivities(Activities):
+    """Concrete Activities with required abstract properties satisfied."""
+
+    @property
+    def tap_stream_id(self):
+        return "activities"
+
+    @property
+    def replication_method(self):
+        return "FULL_TABLE"
+
+    @property
+    def replication_keys(self):
+        return []
+
+    @property
+    def key_properties(self):
+        return ["id"]
+
+
+class ConcreteCustomers(Customers):
+    """Concrete Customers with required abstract properties satisfied."""
+
+    @property
+    def tap_stream_id(self):
+        return "customers"
+
+    @property
+    def replication_method(self):
+        return "FULL_TABLE"
+
+    @property
+    def replication_keys(self):
+        return []
+
+    @property
+    def key_properties(self):
+        return ["id"]
+
+
+
+# ---------------------------------------------------------------------------
+# Activities tests
+# ---------------------------------------------------------------------------
+
+class TestActivitiesGetRecords(unittest.TestCase):
+    """Tests for Activities.get_records() cursor-based pagination."""
+
+    @patch("tap_customerio.streams.abstracts.metadata.to_map")
+    def setUp(self, mock_to_map):
+        mock_catalog = MagicMock()
+        mock_catalog.schema.to_dict.return_value = {}
+        mock_catalog.metadata = []
+        mock_to_map.return_value = {}
+
+        mock_client = MagicMock()
+        mock_client.base_url = "https://api.customer.io/v1"
+
+        self.stream = ConcreteActivities(client=mock_client, catalog=mock_catalog)
+
+    def test_single_page_returns_all_records(self):
+        """A response with no 'next' cursor yields records and stops."""
+        self.stream.client.make_request.return_value = {
+            "activities": [{"id": 1}, {"id": 2}],
+        }
+
+        records = list(self.stream.get_records())
+
+        self.assertEqual(records, [{"id": 1}, {"id": 2}])
+        self.assertEqual(self.stream.client.make_request.call_count, 1)
+
+    def test_multi_page_yields_all_records_in_order(self):
+        """Pagination across two pages yields records from both pages."""
+        self.stream.client.make_request.side_effect = [
+            {"activities": [{"id": 1}, {"id": 2}], "next": "cursor-page2"},
+            {"activities": [{"id": 3}]},
+        ]
+
+        records = list(self.stream.get_records())
+
+        self.assertEqual([r["id"] for r in records], [1, 2, 3])
+        self.assertEqual(self.stream.client.make_request.call_count, 2)
+
+    def test_second_page_request_contains_start_cursor(self):
+        """The 'next' value from page 1 must be sent as 'start' on page 2."""
+        self.stream.client.make_request.side_effect = [
+            {"activities": [{"id": 1}], "next": "cursor-abc"},
+            {"activities": []},
+        ]
+
+        list(self.stream.get_records())
+
+        _, _, second_call_params, *_ = self.stream.client.make_request.call_args_list[1][0]
+        self.assertEqual(second_call_params.get("start"), "cursor-abc")
+
+    def test_first_request_does_not_include_start_param(self):
+        """The very first request must not carry a 'start' parameter."""
+        self.stream.client.make_request.return_value = {"activities": []}
+
+        list(self.stream.get_records())
+
+        _, _, first_call_params, *_ = self.stream.client.make_request.call_args[0]
+        self.assertNotIn("start", first_call_params)
+
+    def test_limit_param_is_always_100(self):
+        """Every request must use limit=100 (max accepted by activities endpoint)."""
+        self.stream.client.make_request.return_value = {"activities": []}
+
+        list(self.stream.get_records())
+
+        _, _, params, *_ = self.stream.client.make_request.call_args[0]
+        self.assertEqual(params.get("limit"), 100)
+
+    @parameterized.expand([
+        ["none_cursor",  None],
+        ["empty_cursor", ""],
+    ])
+    def test_falsy_next_cursor_terminates_pagination(self, name, cursor_value):
+        """Both None and '' as 'next' values must stop iteration after one page."""
+        self.stream.client.make_request.return_value = {
+            "activities": [{"id": 1}],
+            "next": cursor_value,
+        }
+
+        records = list(self.stream.get_records())
+
+        self.assertEqual(len(records), 1)
+        self.assertEqual(self.stream.client.make_request.call_count, 1)
+
+    def test_infinite_loop_guard_empty_page_with_live_cursor(self):
+        """If the API returns no records but a live cursor, we must stop — not loop."""
+        self.stream.client.make_request.return_value = {
+            "activities": [],
+            "next": "stuck-cursor",
+        }
+
+        records = list(self.stream.get_records())
+
+        self.assertEqual(records, [])
+        self.assertEqual(self.stream.client.make_request.call_count, 1)
+
+    @parameterized.expand([
+        ["key_absent",   {}],
+        ["key_is_null",  {"activities": None}],
+        ["key_is_empty", {"activities": []}],
+    ])
+    def test_missing_or_null_data_key_returns_empty_list(self, name, response):
+        """None or absent data_key must not raise TypeError and yields nothing."""
+        self.stream.client.make_request.return_value = response
+
+        records = list(self.stream.get_records())
+
+        self.assertEqual(records, [])
+
+
+# ---------------------------------------------------------------------------
+# Customers tests
+# ---------------------------------------------------------------------------
+
+class TestCustomersGetRecords(unittest.TestCase):
+    """Tests for Customers.get_records() two-step ETL (list IDs → attributes)."""
+
+    @patch("tap_customerio.streams.abstracts.metadata.to_map")
+    def setUp(self, mock_to_map):
+        mock_catalog = MagicMock()
+        mock_catalog.schema.to_dict.return_value = {}
+        mock_catalog.metadata = []
+        mock_to_map.return_value = {}
+
+        mock_client = MagicMock()
+        mock_client.base_url = "https://api.customer.io/v1"
+
+        self.stream = ConcreteCustomers(client=mock_client, catalog=mock_catalog)
+        self.list_url  = "https://api.customer.io/v1/customers"
+        self.attrs_url = "https://api.customer.io/v1/customers/attributes"
+
+    def test_single_page_single_batch_returns_records(self):
+        """Step 1 returns two IDs; step 2 returns two customer records."""
+        self.stream.client.make_request.side_effect = [
+            {"ids": ["id-1", "id-2"], "next": None},
+            {"customers": [{"id": "id-1"}, {"id": "id-2"}]},
+        ]
+
+        records = list(self.stream.get_records())
+
+        self.assertEqual([r["id"] for r in records], ["id-1", "id-2"])
+        self.assertEqual(self.stream.client.make_request.call_count, 2)
+
+    def test_list_endpoint_called_before_attributes_endpoint(self):
+        """Step 1 (list) must always precede step 2 (attributes)"""
+        self.stream.client.make_request.side_effect = [
+            {"ids": ["id-1"], "next": None},
+            {"customers": [{"id": "id-1"}]},
+        ]
+
+        list(self.stream.get_records())
+
+        first_call_url  = self.stream.client.make_request.call_args_list[0][0][1]
+        second_call_url = self.stream.client.make_request.call_args_list[1][0][1]
+        self.assertEqual(first_call_url,  self.list_url)
+        self.assertEqual(second_call_url, self.attrs_url)
+
+    def test_multi_page_list_cursor_forwarded_to_next_request(self):
+        """The 'next' cursor from list page 1 must appear as 'start' in list page 2."""
+        self.stream.client.make_request.side_effect = [
+            {"ids": ["a"], "next": "cursor-page2"},
+            {"customers": [{"id": "a"}]},
+            {"ids": ["b"], "next": None},
+            {"customers": [{"id": "b"}]},
+        ]
+
+        records = list(self.stream.get_records())
+
+        self.assertEqual([r["id"] for r in records], ["a", "b"])
+        list_page2_params = self.stream.client.make_request.call_args_list[2][0][2]
+        self.assertEqual(list_page2_params.get("start"), "cursor-page2")
+
+    def test_ids_exceeding_batch_size_split_into_multiple_attribute_requests(self):
+        """150 IDs must produce 2 attribute requests (batch size = 100)."""
+        ids = [str(i) for i in range(150)]
+        self.stream.client.make_request.side_effect = [
+            {"ids": ids, "next": None},
+            {"customers": [{"id": str(i)} for i in range(100)]},
+            {"customers": [{"id": str(i)} for i in range(100, 150)]},
+        ]
+
+        records = list(self.stream.get_records())
+
+        self.assertEqual(len(records), 150)
+        # 1 list call + 2 batched attribute calls
+        self.assertEqual(self.stream.client.make_request.call_count, 3)
+
+    def test_infinite_loop_guard_empty_ids_with_live_cursor(self):
+        """If list endpoint returns empty ids with a live cursor, we must stop."""
+        self.stream.client.make_request.return_value = {
+            "ids": [],
+            "next": "stuck-cursor",
+        }
+
+        records = list(self.stream.get_records())
+
+        self.assertEqual(records, [])
+        self.assertEqual(self.stream.client.make_request.call_count, 1)
+
+    @parameterized.expand([
+        ["ids_absent",   {"next": None}],
+        ["ids_is_null",  {"ids": None, "next": None}],
+        ["ids_is_empty", {"ids": [],   "next": None}],
+    ])
+    def test_null_or_missing_ids_no_attribute_request_made(self, name, list_response):
+        """Null / absent / empty ids must yield nothing and skip the attributes call."""
+        self.stream.client.make_request.return_value = list_response
+
+        records = list(self.stream.get_records())
+
+        self.assertEqual(records, [])
+        self.assertEqual(self.stream.client.make_request.call_count, 1)
+
+    @parameterized.expand([
+        ["customers_absent",   {}],
+        ["customers_is_null",  {"customers": None}],
+        ["customers_is_empty", {"customers": []}],
+    ])
+    def test_null_or_missing_customers_in_attrs_response_no_crash(self, name, attrs_response):
+        """Null / absent 'customers' in attributes response must not raise TypeError."""
+        self.stream.client.make_request.side_effect = [
+            {"ids": ["x"], "next": None},
+            attrs_response,
+        ]
+
+        records = list(self.stream.get_records())
+
+        self.assertEqual(records, [])
+
+    def test_list_request_body_uses_all_customers_filter(self):
+        """POST /customers body must contain the ALL_CUSTOMERS_FILTER payload."""
+        self.stream.client.make_request.return_value = {"ids": [], "next": None}
+
+        list(self.stream.get_records())
+
+        list_call_kwargs = self.stream.client.make_request.call_args_list[0][1]
+        sent_body = json.loads(list_call_kwargs.get("body", "{}"))
+        self.assertEqual(sent_body, ALL_CUSTOMERS_FILTER)
+
+    def test_content_type_header_forwarded_to_both_endpoints(self):
+        """Content-Type: application/json must be present on every request after authenticate() fix."""
+        self.stream.client.make_request.side_effect = [
+            {"ids": ["x"], "next": None},
+            {"customers": [{"id": "x"}]},
+        ]
+
+        list(self.stream.get_records())
+
+        for idx, api_call in enumerate(self.stream.client.make_request.call_args_list):
+            headers = api_call[0][3]
+            self.assertIn(
+                "Content-Type", headers,
+                msg=f"Content-Type missing from call #{idx + 1}",
+            )
+            self.assertEqual(headers["Content-Type"], "application/json")

--- a/tests/unittests/test_streams_get_records.py
+++ b/tests/unittests/test_streams_get_records.py
@@ -1,4 +1,4 @@
-"""Unit tests for Activities.get_records() and Customers.get_records().
+"""Unit tests for Activities.get_records(), Customers.get_records(), and Newsletters.get_records().
 
 Covers:
  - Cursor-based pagination (single and multi-page)
@@ -8,6 +8,7 @@ Covers:
  - Null-safe handling when API returns null for ids / customers keys
  - Two-step flow in Customers (list IDs → fetch attributes in batches)
  - Content-Type header propagation after authenticate() merge fix
+ - Newsletters: updated_since bookmark filter forwarded via self.params
 """
 import json
 import unittest
@@ -19,6 +20,7 @@ from tap_customerio.streams.customers import (
     ALL_CUSTOMERS_FILTER,
     Customers,
 )
+from tap_customerio.streams.newsletters import Newsletters
 
 
 class ConcreteActivities(Activities):
@@ -321,3 +323,125 @@ class TestCustomersGetRecords(unittest.TestCase):
                 msg=f"Content-Type missing from call #{idx + 1}",
             )
             self.assertEqual(headers["Content-Type"], "application/json")
+
+
+# ---------------------------------------------------------------------------
+# Newsletters tests
+# ---------------------------------------------------------------------------
+
+class ConcreteNewsletters(Newsletters):
+    """Concrete Newsletters with required abstract properties satisfied."""
+
+    @property
+    def tap_stream_id(self):
+        return "newsletters"
+
+    @property
+    def replication_method(self):
+        return "INCREMENTAL"
+
+    @property
+    def replication_keys(self):
+        return ["updated"]
+
+    @property
+    def key_properties(self):
+        return ["id"]
+
+
+class TestNewslettersGetRecords(unittest.TestCase):
+    """Tests for Newsletters.get_records() — verifies base-class pagination is used."""
+
+    @patch("tap_customerio.streams.abstracts.metadata.to_map")
+    def setUp(self, mock_to_map):
+        mock_catalog = MagicMock()
+        mock_catalog.schema.to_dict.return_value = {}
+        mock_catalog.metadata = []
+        mock_to_map.return_value = {}
+
+        mock_client = MagicMock()
+        mock_client.base_url = "https://api.customer.io/v1"
+
+        self.stream = ConcreteNewsletters(client=mock_client, catalog=mock_catalog)
+        # Simulate the bookmark filter that IncrementalStream.sync() sets via update_params()
+        self.stream.params["updated_since"] = 1700000000
+
+    def test_single_page_returns_all_records(self):
+        """A response with no 'next' cursor yields records and stops."""
+        self.stream.client.make_request.return_value = {
+            "newsletters": [{"id": 1}, {"id": 2}],
+        }
+
+        records = list(self.stream.get_records())
+
+        self.assertEqual(records, [{"id": 1}, {"id": 2}])
+        self.assertEqual(self.stream.client.make_request.call_count, 1)
+
+    def test_multi_page_yields_all_records_in_order(self):
+        """Pagination across two pages yields records from both pages."""
+        self.stream.client.make_request.side_effect = [
+            {"newsletters": [{"id": 1}], "next": "cursor-page2"},
+            {"newsletters": [{"id": 2}]},
+        ]
+
+        records = list(self.stream.get_records())
+
+        self.assertEqual([r["id"] for r in records], [1, 2])
+        self.assertEqual(self.stream.client.make_request.call_count, 2)
+
+    def test_second_page_request_contains_start_cursor(self):
+        """The 'next' value from page 1 must be sent as 'start' on page 2."""
+        self.stream.client.make_request.side_effect = [
+            {"newsletters": [{"id": 1}], "next": "cursor-abc"},
+            {"newsletters": []},
+        ]
+
+        list(self.stream.get_records())
+
+        second_call_params = self.stream.client.make_request.call_args_list[1][0][2]
+        self.assertEqual(second_call_params.get("start"), "cursor-abc")
+
+    def test_updated_since_bookmark_forwarded_to_api(self):
+        """The updated_since param set via update_params() must be sent to the API."""
+        self.stream.client.make_request.return_value = {"newsletters": []}
+
+        list(self.stream.get_records())
+
+        first_call_params = self.stream.client.make_request.call_args[0][2]
+        self.assertIn("updated_since", first_call_params)
+        self.assertEqual(first_call_params["updated_since"], 1700000000)
+
+    def test_limit_param_is_sent(self):
+        """The 'limit' page-size parameter must be present on every request."""
+        self.stream.client.make_request.return_value = {"newsletters": []}
+
+        list(self.stream.get_records())
+
+        first_call_params = self.stream.client.make_request.call_args[0][2]
+        self.assertIn("limit", first_call_params)
+        self.assertEqual(first_call_params["limit"], self.stream.page_size)
+
+    def test_falsy_next_cursor_terminates_pagination(self):
+        """A None 'next' value must stop iteration after one page."""
+        self.stream.client.make_request.return_value = {
+            "newsletters": [{"id": 1}],
+            "next": None,
+        }
+
+        records = list(self.stream.get_records())
+
+        self.assertEqual(len(records), 1)
+        self.assertEqual(self.stream.client.make_request.call_count, 1)
+
+    @parameterized.expand([
+        ["key_absent",   {}],
+        ["key_is_null",  {"newsletters": None}],
+        ["key_is_empty", {"newsletters": []}],
+    ])
+    def test_missing_or_null_data_key_returns_empty_list(self, name, response):
+        """None or absent data_key must not raise TypeError and yields nothing."""
+        self.stream.client.make_request.return_value = response
+
+        records = list(self.stream.get_records())
+
+        self.assertEqual(records, [])


### PR DESCRIPTION
# Description of change

Updates stream pagination behavior to better align with Customer.io API requirements, particularly for cursor-based pagination and the two-step customer export flow.

**Changes:**
- Implement two-step customer retrieval: fetch IDs from `/customers`, then resolve attributes via `/customers/attributes` in batches.
- Override activities pagination to map response cursor (`next`) to request parameter (`start`) and enforce the endpoint’s `limit` constraint.

Ticket: [SAC-29869](https://qlik-dev.atlassian.net/browse/SAC-29869)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
