### PR TITLE
remove stream from catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.1
+  * Bump version for singer-python, requests to latest. [#16](https://github.com/singer-io/tap-customerio/pull/16)
+
 ## 0.1.0
   * Updated python version. Fixed Integration Tests. [#13](https://github.com/singer-io/tap-customerio/pull/13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.1.1
-  * Bump version for singer-python, requests to latest. [#16](https://github.com/singer-io/tap-customerio/pull/16)
+## 0.2.0
+  * Exclude 403-forbidden streams from discovery [#16](https://github.com/singer-io/tap-customerio/pull/16)
+  * Bump dependencies for compliance
 
 ## 0.1.0
   * Updated python version. Fixed Integration Tests. [#13](https://github.com/singer-io/tap-customerio/pull/13)

--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,15 @@ from setuptools import setup, find_packages
 
 
 setup(name="tap-customerio",
-      version="0.1.0",
+      version="0.1.1",
       description="Singer.io tap for extracting data from customerio API",
       author="Stitch",
       url="http://singer.io",
       classifiers=["Programming Language :: Python :: 3 :: Only"],
       py_modules=["tap_customerio"],
       install_requires=[
-        "singer-python==6.1.1",
-        "requests==2.33.1",
+        "singer-python==6.8.0",
+        "requests==2.34.2",
         "backoff==2.2.1",
         "parameterized"
       ],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="tap-customerio",
-      version="0.1.1",
+      version="0.2.0",
       description="Singer.io tap for extracting data from customerio API",
       author="Stitch",
       url="http://singer.io",

--- a/tap_customerio/__init__.py
+++ b/tap_customerio/__init__.py
@@ -9,12 +9,12 @@ LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = ['access_token', 'start_date']
 
-def do_discover():
+def do_discover(client):
     """
     Discover and emit the catalog to stdout
     """
     LOGGER.info("Starting discover")
-    catalog = discover()
+    catalog = discover(client)
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info("Finished discover")
 
@@ -31,7 +31,7 @@ def main():
 
     with Client(parsed_args.config) as client:
         if parsed_args.discover:
-            do_discover()
+            do_discover(client)
         elif parsed_args.catalog:
             sync(
                 client=client,

--- a/tap_customerio/client.py
+++ b/tap_customerio/client.py
@@ -70,7 +70,7 @@ class Client:
     def make_request(
         self,
         method: str,
-        endpoint: str,
+        endpoint: Optional[str] = None,
         params: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, Any]] = None,
         body: Optional[Dict[str, Any]] = None,

--- a/tap_customerio/discover.py
+++ b/tap_customerio/discover.py
@@ -13,8 +13,10 @@ def discover(client=None) -> Catalog:
     """
     Run the discovery mode, prepare the catalog file and return the catalog.
     If a client is provided, each stream's endpoint is tested for accessibility.
-    Streams that are inaccessible (due to permissions or any other reason) are
-    skipped and will not appear in the catalog.
+    Streams that return HTTP 403 (Forbidden) are excluded from the catalog.
+    HTTP 401 (Unauthorized) raises immediately as it indicates an invalid token.
+    Any other error during probing is logged as a warning and the stream is
+    included in the catalog, since permissions cannot be determined.
     """
     schemas, field_metadata = get_schemas()
     catalog = Catalog([])
@@ -40,7 +42,7 @@ def discover(client=None) -> Catalog:
                     fmt = {}
                     for ph in placeholders:
                         values = getattr(stream_class, ph + 's', None)
-                        if isinstance(values, list) and values:
+                        if isinstance(values, (list, tuple)) and values:
                             fmt[ph] = values[0]
                     if len(fmt) == len(placeholders):
                         path = path.format(**fmt)
@@ -49,7 +51,14 @@ def discover(client=None) -> Catalog:
                 if path is not None:
                     try:
                         client.make_request(stream_class.http_method, "", params={"limit": 1}, path=path)
-                    except (customerioUnauthorizedError, customerioForbiddenError) as err:
+                    except customerioUnauthorizedError:
+                        LOGGER.critical(
+                            "Authentication failed during discovery for stream '%s': "
+                            "invalid or expired access token.",
+                            stream_name
+                        )
+                        raise
+                    except customerioForbiddenError as err:
                         LOGGER.warning(
                             "Skipping stream '%s' from catalog: insufficient permissions (HTTP %s). Error: %s",
                             stream_name,

--- a/tap_customerio/discover.py
+++ b/tap_customerio/discover.py
@@ -1,14 +1,20 @@
+import re
 import singer
 from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_customerio.schema import get_schemas
+from tap_customerio.streams import STREAMS
+from tap_customerio.exceptions import customerioUnauthorizedError, customerioForbiddenError
 
 LOGGER = singer.get_logger()
 
 
-def discover() -> Catalog:
+def discover(client=None) -> Catalog:
     """
     Run the discovery mode, prepare the catalog file and return the catalog.
+    If a client is provided, each stream's endpoint is tested for accessibility.
+    Streams that are inaccessible (due to permissions or any other reason) are
+    skipped and will not appear in the catalog.
     """
     schemas, field_metadata = get_schemas()
     catalog = Catalog([])
@@ -22,6 +28,35 @@ def discover() -> Catalog:
             LOGGER.error("stream_name: {}".format(stream_name))
             LOGGER.error("type schema_dict: {}".format(type(schema_dict)))
             raise err
+
+        if client is not None:
+            stream_class = STREAMS.get(stream_name)
+            if stream_class is not None:
+                path = stream_class.path
+                if "{" in path:
+                    # Resolve template placeholders using class-level list attributes
+                    # e.g. {suppression_type} -> suppression_types[0]
+                    placeholders = re.findall(r'\{(\w+)\}', path)
+                    fmt = {}
+                    for ph in placeholders:
+                        values = getattr(stream_class, ph + 's', None)
+                        if isinstance(values, list) and values:
+                            fmt[ph] = values[0]
+                    if len(fmt) == len(placeholders):
+                        path = path.format(**fmt)
+                    else:
+                        path = None  # Cannot resolve all placeholders, skip probing
+                if path is not None:
+                    try:
+                        client.make_request(stream_class.http_method, "", params={"limit": 1}, path=path)
+                    except (customerioUnauthorizedError, customerioForbiddenError) as err:
+                        LOGGER.warning(
+                            "Skipping stream '%s' from catalog: insufficient permissions (HTTP %s). Error: %s",
+                            stream_name,
+                            err.response.status_code if err.response is not None else "unknown",
+                            err
+                        )
+                        continue
 
         key_properties = metadata.to_map(mdata).get((), {}).get("table-key-properties")
 

--- a/tap_customerio/discover.py
+++ b/tap_customerio/discover.py
@@ -57,6 +57,14 @@ def discover(client=None) -> Catalog:
                             err
                         )
                         continue
+                    except Exception as err:
+                        # Any other error (400, 404, 500, network, etc.) means we cannot
+                        # determine permissions — include the stream in the catalog.
+                        LOGGER.warning(
+                            "Could not verify access for stream '%s' during discovery: %s. "
+                            "Including in catalog.",
+                            stream_name, err
+                        )
 
         key_properties = metadata.to_map(mdata).get((), {}).get("table-key-properties")
 

--- a/tap_customerio/discover.py
+++ b/tap_customerio/discover.py
@@ -1,13 +1,9 @@
-import re
 import singer
 from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_customerio.schema import get_schemas
-from tap_customerio.streams import STREAMS
-from tap_customerio.exceptions import customerioUnauthorizedError, customerioForbiddenError
 
 LOGGER = singer.get_logger()
-
 
 def discover(client=None) -> Catalog:
     """
@@ -15,10 +11,8 @@ def discover(client=None) -> Catalog:
     If a client is provided, each stream's endpoint is tested for accessibility.
     Streams that return HTTP 403 (Forbidden) are excluded from the catalog.
     HTTP 401 (Unauthorized) raises immediately as it indicates an invalid token.
-    Any other error during probing is logged as a warning and the stream is
-    included in the catalog, since permissions cannot be determined.
     """
-    schemas, field_metadata = get_schemas()
+    schemas, field_metadata = get_schemas(client)
     catalog = Catalog([])
 
     for stream_name, schema_dict in schemas.items():
@@ -30,50 +24,6 @@ def discover(client=None) -> Catalog:
             LOGGER.error("stream_name: {}".format(stream_name))
             LOGGER.error("type schema_dict: {}".format(type(schema_dict)))
             raise err
-
-        if client is not None:
-            stream_class = STREAMS.get(stream_name)
-            if stream_class is not None:
-                path = stream_class.path
-                if "{" in path:
-                    # Resolve template placeholders using class-level list attributes
-                    # e.g. {suppression_type} -> suppression_types[0]
-                    placeholders = re.findall(r'\{(\w+)\}', path)
-                    fmt = {}
-                    for ph in placeholders:
-                        values = getattr(stream_class, ph + 's', None)
-                        if isinstance(values, (list, tuple)) and values:
-                            fmt[ph] = values[0]
-                    if len(fmt) == len(placeholders):
-                        path = path.format(**fmt)
-                    else:
-                        path = None  # Cannot resolve all placeholders, skip probing
-                if path is not None:
-                    try:
-                        client.make_request(stream_class.http_method, "", params={"limit": 1}, path=path)
-                    except customerioUnauthorizedError:
-                        LOGGER.critical(
-                            "Authentication failed during discovery for stream '%s': "
-                            "invalid or expired access token.",
-                            stream_name
-                        )
-                        raise
-                    except customerioForbiddenError as err:
-                        LOGGER.warning(
-                            "Skipping stream '%s' from catalog: insufficient permissions (HTTP %s). Error: %s",
-                            stream_name,
-                            err.response.status_code if err.response is not None else "unknown",
-                            err
-                        )
-                        continue
-                    except Exception as err:
-                        # Any other error (400, 404, 500, network, etc.) means we cannot
-                        # determine permissions — include the stream in the catalog.
-                        LOGGER.warning(
-                            "Could not verify access for stream '%s' during discovery: %s. "
-                            "Including in catalog.",
-                            stream_name, err
-                        )
 
         key_properties = metadata.to_map(mdata).get((), {}).get("table-key-properties")
 

--- a/tap_customerio/discover.py
+++ b/tap_customerio/discover.py
@@ -5,10 +5,10 @@ from tap_customerio.schema import get_schemas
 
 LOGGER = singer.get_logger()
 
-def discover(client=None) -> Catalog:
+def discover(client) -> Catalog:
     """
     Run the discovery mode, prepare the catalog file and return the catalog.
-    If a client is provided, each stream's endpoint is tested for accessibility.
+    Each stream's endpoint is tested for accessibility.
     Streams that return HTTP 403 (Forbidden) are excluded from the catalog.
     HTTP 401 (Unauthorized) raises immediately as it indicates an invalid token.
     """

--- a/tap_customerio/schema.py
+++ b/tap_customerio/schema.py
@@ -4,8 +4,46 @@ import singer
 from typing import Dict, Tuple
 from singer import metadata
 from tap_customerio.streams import STREAMS
+from tap_customerio.exceptions import customerioUnauthorizedError, customerioForbiddenError
 
 LOGGER = singer.get_logger()
+
+
+def _resolve_probe_path(stream_class):
+    """
+    Returns a concrete probe path for the stream class.
+    For templated paths, uses the first value from suppression_types.
+    """
+    if stream_class.suppression_types:
+        return stream_class.path.format(suppression_type=stream_class.suppression_types[0])
+    return stream_class.path
+
+
+def has_stream_access(client, stream_name, stream_class):
+    """
+    Probes the stream endpoint to verify access permissions.
+
+    Returns True if accessible, False on HTTP 403 (stream excluded from catalog).
+    Raises immediately on HTTP 401 (invalid token).
+    All other errors are re-raised.
+    """
+    probe_path = _resolve_probe_path(stream_class)
+    try:
+        client.make_request(stream_class.http_method, "", params={"limit": 1}, path=probe_path)
+        return True
+    except customerioUnauthorizedError as ex:
+        raise Exception(
+            "Authentication failed during discovery for stream '%s': "
+            "invalid or expired access token." % stream_name
+        ) from ex
+    except customerioForbiddenError as err:
+        LOGGER.warning(
+            "Skipping stream '%s' from catalog: insufficient permissions (HTTP %s). Error: %s",
+            stream_name,
+            err.response.status_code if err.response is not None else "unknown",
+            err
+        )
+        return False
 
 
 def get_abs_path(path: str) -> str:
@@ -37,15 +75,21 @@ def load_schema_references() -> Dict:
     return refs
 
 
-def get_schemas() -> Tuple[Dict, Dict]:
+def get_schemas(client=None) -> Tuple[Dict, Dict]:
     """
-    Load the schema references, prepare metadata for each streams and return schema and metadata for the catalog.
+    Load the schema references, prepare metadata for each stream and return
+    schema and metadata for the catalog.
+    If a client is provided, each stream's endpoint is probed for access;
+    streams returning HTTP 403 are excluded.
     """
     schemas = {}
     field_metadata = {}
 
     refs = load_schema_references()
     for stream_name, stream_obj in STREAMS.items():
+        if client is not None and not has_stream_access(client, stream_name, stream_obj):
+            continue
+
         schema_path = get_abs_path("schemas/{}.json".format(stream_name))
         with open(schema_path) as file:
             schema = json.load(file)

--- a/tap_customerio/schema.py
+++ b/tap_customerio/schema.py
@@ -25,7 +25,7 @@ def has_stream_access(client, stream_name, stream_class):
 
     Returns True if accessible, False on HTTP 403 (stream excluded from catalog).
     Raises immediately on HTTP 401 (invalid token).
-    All other errors are re-raised.
+    All other exceptions propagate unchanged.
 
     For GET streams, a lightweight request with limit=1 is used.
     For POST streams, the stream's probe_body is sent as a minimal valid request.
@@ -46,7 +46,8 @@ def has_stream_access(client, stream_name, stream_class):
     except customerioUnauthorizedError as ex:
         raise Exception(
             "Authentication failed during discovery for stream '%s': "
-            "invalid or expired access token." % stream_name
+            "invalid or expired access token.",
+            stream_name
         ) from ex
     except customerioForbiddenError as err:
         LOGGER.warning(
@@ -87,19 +88,18 @@ def load_schema_references() -> Dict:
     return refs
 
 
-def get_schemas(client=None) -> Tuple[Dict, Dict]:
+def get_schemas(client) -> Tuple[Dict, Dict]:
     """
     Load the schema references, prepare metadata for each stream and return
     schema and metadata for the catalog.
-    If a client is provided, each stream's endpoint is probed for access;
-    streams returning HTTP 403 are excluded.
+    Each stream's endpoint is probed for access; streams returning HTTP 403 are excluded.
     """
     schemas = {}
     field_metadata = {}
 
     refs = load_schema_references()
     for stream_name, stream_obj in STREAMS.items():
-        if client is not None and not has_stream_access(client, stream_name, stream_obj):
+        if not has_stream_access(client, stream_name, stream_obj):
             continue
 
         schema_path = get_abs_path("schemas/{}.json".format(stream_name))
@@ -130,4 +130,3 @@ def get_schemas(client=None) -> Tuple[Dict, Dict]:
         field_metadata[stream_name] = mdata
 
     return schemas, field_metadata
-

--- a/tap_customerio/schema.py
+++ b/tap_customerio/schema.py
@@ -33,11 +33,10 @@ def has_stream_access(client, stream_name, stream_class):
     probe_path = _resolve_probe_path(stream_class)
     try:
         if stream_class.http_method == "GET":
-            client.make_request("GET", "", params={"limit": 1}, path=probe_path)
+            client.make_request("GET", params={"limit": 1}, path=probe_path)
         else:
             client.make_request(
                 stream_class.http_method,
-                "",
                 headers={"Content-Type": "application/json"},
                 body=json.dumps(stream_class.probe_body or {}),
                 path=probe_path,

--- a/tap_customerio/schema.py
+++ b/tap_customerio/schema.py
@@ -26,10 +26,22 @@ def has_stream_access(client, stream_name, stream_class):
     Returns True if accessible, False on HTTP 403 (stream excluded from catalog).
     Raises immediately on HTTP 401 (invalid token).
     All other errors are re-raised.
+
+    For GET streams, a lightweight request with limit=1 is used.
+    For POST streams, the stream's probe_body is sent as a minimal valid request.
     """
     probe_path = _resolve_probe_path(stream_class)
     try:
-        client.make_request(stream_class.http_method, "", params={"limit": 1}, path=probe_path)
+        if stream_class.http_method == "GET":
+            client.make_request("GET", "", params={"limit": 1}, path=probe_path)
+        else:
+            client.make_request(
+                stream_class.http_method,
+                "",
+                headers={"Content-Type": "application/json"},
+                body=json.dumps(stream_class.probe_body or {}),
+                path=probe_path,
+            )
         return True
     except customerioUnauthorizedError as ex:
         raise Exception(

--- a/tap_customerio/streams/abstracts.py
+++ b/tap_customerio/streams/abstracts.py
@@ -37,6 +37,7 @@ class BaseStream(ABC):
     data_key = ""
     parent_bookmark_key = ""
     http_method = "GET"
+    suppression_types = None
 
     def __init__(self, client=None, catalog=None) -> None:
         self.client = client

--- a/tap_customerio/streams/abstracts.py
+++ b/tap_customerio/streams/abstracts.py
@@ -38,6 +38,7 @@ class BaseStream(ABC):
     parent_bookmark_key = ""
     http_method = "GET"
     suppression_types = None
+    probe_body = None
 
     def __init__(self, client=None, catalog=None) -> None:
         self.client = client

--- a/tap_customerio/streams/customers.py
+++ b/tap_customerio/streams/customers.py
@@ -32,6 +32,7 @@ class Customers(FullTableStream):
     data_key = "customers"
     path = "customers/attributes"
     http_method = "POST"
+    probe_body = {"ids": []}
 
     def get_records(self) -> Iterator:
         """

--- a/tap_customerio/streams/eps_suppression.py
+++ b/tap_customerio/streams/eps_suppression.py
@@ -10,7 +10,7 @@ class EpsSuppression(FullTableStream):
     replication_keys = []
     data_key = "suppressions"
     path = "esp/suppression/{suppression_type}"
-    suppression_types = ["bounces", "spam_reports"]
+    suppression_types = ("bounces", "spam_reports")
 
     def get_records(self) -> Iterator[Dict]:
         suppression_types = self.suppression_types

--- a/tap_customerio/streams/eps_suppression.py
+++ b/tap_customerio/streams/eps_suppression.py
@@ -10,9 +10,10 @@ class EpsSuppression(FullTableStream):
     replication_keys = []
     data_key = "suppressions"
     path = "esp/suppression/{suppression_type}"
+    suppression_types = ["bounces", "spam_reports"]
 
     def get_records(self) -> Iterator[Dict]:
-        suppression_types = ["bounces", "spam_reports"]
+        suppression_types = self.suppression_types
         self.params["page"] = self.page_size
         for suppression_type in suppression_types:
             path = self.path.format(suppression_type=suppression_type)

--- a/tap_customerio/streams/eps_suppression.py
+++ b/tap_customerio/streams/eps_suppression.py
@@ -13,9 +13,8 @@ class EpsSuppression(FullTableStream):
     suppression_types = ("bounces", "spam_reports")
 
     def get_records(self) -> Iterator[Dict]:
-        suppression_types = self.suppression_types
         self.params["page"] = self.page_size
-        for suppression_type in suppression_types:
+        for suppression_type in self.suppression_types:
             path = self.path.format(suppression_type=suppression_type)
             next_page = 1
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -47,13 +47,6 @@ class customerioBaseTest(BaseCase):
                 cls.RESPECTS_START_DATE: True,
                 cls.API_LIMIT: 1
             },
-            "customers": {
-                cls.PRIMARY_KEYS: { "id" },
-                cls.REPLICATION_METHOD: cls.FULL_TABLE,
-                cls.REPLICATION_KEYS: set(),
-                cls.RESPECTS_START_DATE: False,
-                cls.API_LIMIT: 1
-            },
             "campaigns": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,

--- a/tests/base.py
+++ b/tests/base.py
@@ -47,6 +47,14 @@ class customerioBaseTest(BaseCase):
                 cls.RESPECTS_START_DATE: True,
                 cls.API_LIMIT: 1
             },
+            "customers": {
+                cls.PRIMARY_KEYS: { "id" },
+                cls.REPLICATION_METHOD: cls.FULL_TABLE,
+                cls.REPLICATION_KEYS: set(),
+                cls.RESPECTS_START_DATE: False,
+                cls.API_LIMIT: 1,
+                cls.IS_FORBIDDEN_STREAM: True
+            },
             "campaigns": {
                 cls.PRIMARY_KEYS: { "id" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
@@ -169,5 +177,13 @@ class customerioBaseTest(BaseCase):
         """Configuration of properties required for the tap."""
         return {
             "start_date" : self.start_date
+        }
+
+    def expected_stream_names(self):
+        """The expected stream names and exclude forbidden streams."""
+        return {
+            stream_name
+            for stream_name, metadata in self.expected_metadata().items()
+            if not metadata.get(self.IS_FORBIDDEN_STREAM, False)
         }
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -18,6 +18,7 @@ class customerioBaseTest(BaseCase):
     in tap-tester tests. Shared tap-specific methods (as needed).
     """
     start_date = "2019-01-01T00:00:00Z"
+    IS_FORBIDDEN_STREAM = "is-forbidden-stream"
 
     @staticmethod
     def tap_name():

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,0 +1,117 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tap_customerio.discover import discover
+from tap_customerio.exceptions import (
+    customerioForbiddenError,
+    customerioUnauthorizedError,
+    customerioBadRequestError,
+)
+
+
+def _make_client(side_effect=None):
+    client = MagicMock()
+    if side_effect is not None:
+        client.make_request.side_effect = side_effect
+    return client
+
+
+class TestDiscoverWithoutClient(unittest.TestCase):
+    """discover() with no client should return all streams without probing."""
+
+    def test_returns_all_streams_when_no_client(self):
+        catalog = discover(client=None)
+        self.assertIsNotNone(catalog)
+        self.assertGreater(len(catalog.streams), 0)
+
+
+class TestDiscoverProbing(unittest.TestCase):
+    """discover() with a client probes each stream endpoint."""
+
+    def test_stream_included_on_successful_probe(self):
+        client = _make_client(side_effect=None)  # no error -> success
+        catalog = discover(client=client)
+        stream_names = {s.stream for s in catalog.streams}
+        self.assertIn("campaigns", stream_names)
+
+    def test_stream_excluded_on_403(self):
+        forbidden_response = MagicMock()
+        forbidden_response.status_code = 403
+        forbidden_err = customerioForbiddenError("HTTP-error-code: 403", forbidden_response)
+
+        def side_effect(method, endpoint, params=None, path=None, **kwargs):
+            if path == "campaigns":
+                raise forbidden_err
+            # all other streams succeed
+
+        client = _make_client(side_effect=side_effect)
+        catalog = discover(client=client)
+        stream_names = {s.stream for s in catalog.streams}
+        self.assertNotIn("campaigns", stream_names)
+
+    def test_stream_included_on_non_permission_error(self):
+        bad_request_response = MagicMock()
+        bad_request_response.status_code = 400
+        bad_request_err = customerioBadRequestError("HTTP-error-code: 400", bad_request_response)
+
+        def side_effect(method, endpoint, params=None, path=None, **kwargs):
+            if path == "campaigns":
+                raise bad_request_err
+            # all other streams succeed
+
+        client = _make_client(side_effect=side_effect)
+        catalog = discover(client=client)
+        stream_names = {s.stream for s in catalog.streams}
+        # 400 must NOT exclude the stream — permissions could not be determined
+        self.assertIn("campaigns", stream_names)
+
+    def test_401_raises_immediately(self):
+        unauthorized_response = MagicMock()
+        unauthorized_response.status_code = 401
+        unauthorized_err = customerioUnauthorizedError("HTTP-error-code: 401", unauthorized_response)
+
+        client = _make_client(side_effect=unauthorized_err)
+        with self.assertRaises(customerioUnauthorizedError):
+            discover(client=client)
+
+    def test_eps_suppression_included_on_successful_probe(self):
+        """eps_suppression path is templated; it should be probed with first suppression_type."""
+        client = _make_client(side_effect=None)
+        catalog = discover(client=client)
+        stream_names = {s.stream for s in catalog.streams}
+        self.assertIn("eps_suppression", stream_names)
+
+    def test_eps_suppression_excluded_on_403(self):
+        forbidden_response = MagicMock()
+        forbidden_response.status_code = 403
+        forbidden_err = customerioForbiddenError("HTTP-error-code: 403", forbidden_response)
+
+        def side_effect(method, endpoint, params=None, path=None, **kwargs):
+            if path == "esp/suppression/bounces":
+                raise forbidden_err
+
+        client = _make_client(side_effect=side_effect)
+        catalog = discover(client=client)
+        stream_names = {s.stream for s in catalog.streams}
+        self.assertNotIn("eps_suppression", stream_names)
+
+    def test_multiple_streams_excluded_on_403(self):
+        forbidden_response = MagicMock()
+        forbidden_response.status_code = 403
+        forbidden_err = customerioForbiddenError("HTTP-error-code: 403", forbidden_response)
+
+        restricted = {"campaigns", "broadcasts"}
+
+        def side_effect(method, endpoint, params=None, path=None, **kwargs):
+            if path in restricted:
+                raise forbidden_err
+
+        client = _make_client(side_effect=side_effect)
+        catalog = discover(client=client)
+        stream_names = {s.stream for s in catalog.streams}
+        for stream in restricted:
+            self.assertNotIn(stream, stream_names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -18,11 +18,12 @@ def _make_client(side_effect=None):
     return client
 
 
-class TestDiscoverWithoutClient(unittest.TestCase):
-    """discover() with no client should return all streams without probing."""
+class TestDiscoverWithClient(unittest.TestCase):
+    """discover() with a client returns all accessible streams."""
 
-    def test_returns_all_streams_when_no_client(self):
-        catalog = discover(client=None)
+    def test_returns_all_streams_when_all_accessible(self):
+        client = _make_client(side_effect=None)
+        catalog = discover(client=client)
         self.assertIsNotNone(catalog)
         self.assertGreater(len(catalog.streams), 0)
 

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from tap_customerio.discover import discover
 from tap_customerio.exceptions import (
@@ -49,7 +49,7 @@ class TestDiscoverProbing(unittest.TestCase):
         stream_names = {s.stream for s in catalog.streams}
         self.assertNotIn("campaigns", stream_names)
 
-    def test_stream_included_on_non_permission_error(self):
+    def test_non_permission_error_reraises(self):
         bad_request_response = MagicMock()
         bad_request_response.status_code = 400
         bad_request_err = customerioBadRequestError("HTTP-error-code: 400", bad_request_response)
@@ -57,13 +57,11 @@ class TestDiscoverProbing(unittest.TestCase):
         def side_effect(method, endpoint, params=None, path=None, **kwargs):
             if path == "campaigns":
                 raise bad_request_err
-            # all other streams succeed
 
         client = _make_client(side_effect=side_effect)
-        catalog = discover(client=client)
-        stream_names = {s.stream for s in catalog.streams}
-        # 400 must NOT exclude the stream — permissions could not be determined
-        self.assertIn("campaigns", stream_names)
+        # 400 is not a permission error — it re-raises and does not silently include the stream
+        with self.assertRaises(customerioBadRequestError):
+            discover(client=client)
 
     def test_401_raises_immediately(self):
         unauthorized_response = MagicMock()
@@ -71,8 +69,9 @@ class TestDiscoverProbing(unittest.TestCase):
         unauthorized_err = customerioUnauthorizedError("HTTP-error-code: 401", unauthorized_response)
 
         client = _make_client(side_effect=unauthorized_err)
-        with self.assertRaises(customerioUnauthorizedError):
+        with self.assertRaises(Exception) as ctx:
             discover(client=client)
+        self.assertIsInstance(ctx.exception.__cause__, customerioUnauthorizedError)
 
     def test_eps_suppression_included_on_successful_probe(self):
         """eps_suppression path is templated; it should be probed with first suppression_type."""

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -2,11 +2,13 @@ import unittest
 from unittest.mock import MagicMock
 
 from tap_customerio.discover import discover
+from tap_customerio.schema import has_stream_access
 from tap_customerio.exceptions import (
     customerioForbiddenError,
     customerioUnauthorizedError,
     customerioBadRequestError,
 )
+from tap_customerio.streams.customers import Customers
 
 
 def _make_client(side_effect=None):
@@ -110,6 +112,49 @@ class TestDiscoverProbing(unittest.TestCase):
         stream_names = {s.stream for s in catalog.streams}
         for stream in restricted:
             self.assertNotIn(stream, stream_names)
+
+    def test_customers_stream_probed_with_post_method(self):
+        """customers stream (POST) must be probed using POST with probe_body, not skipped."""
+        import json
+        client = _make_client()
+        catalog = discover(client=client)
+        stream_names = {s.stream for s in catalog.streams}
+        self.assertIn("customers", stream_names)
+        # Verify the probe used POST to customers/attributes with probe_body
+        matched = [
+            call for call in client.make_request.call_args_list
+            if call.kwargs.get("path") == "customers/attributes"
+        ]
+        self.assertTrue(matched, "Expected a probe call to customers/attributes")
+        self.assertEqual(matched[0].args[0], "POST")
+        self.assertEqual(json.loads(matched[0].kwargs.get("body", "{}")), {"ids": []})
+
+    def test_customers_stream_excluded_on_403(self):
+        """customers stream is excluded from catalog when POST probe returns 403."""
+        forbidden_response = MagicMock()
+        forbidden_response.status_code = 403
+        forbidden_err = customerioForbiddenError("HTTP-error-code: 403", forbidden_response)
+
+        def side_effect(method, endpoint, params=None, path=None, **kwargs):
+            if path == "customers/attributes" and method == "POST":
+                raise forbidden_err
+
+        client = _make_client(side_effect=side_effect)
+        catalog = discover(client=client)
+        stream_names = {s.stream for s in catalog.streams}
+        self.assertNotIn("customers", stream_names)
+
+    def test_has_stream_access_uses_post_for_post_stream(self):
+        """has_stream_access probes POST streams using POST + probe_body."""
+        import json
+        client = _make_client()
+        result = has_stream_access(client, "customers", Customers)
+        self.assertTrue(result)
+        client.make_request.assert_called_once()
+        call = client.make_request.call_args
+        self.assertEqual(call.args[0], "POST")
+        self.assertEqual(call.kwargs.get("path"), "customers/attributes")
+        self.assertEqual(json.loads(call.kwargs.get("body", "{}")), {"ids": []})
 
 
 if __name__ == "__main__":

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -42,7 +42,7 @@ class TestDiscoverProbing(unittest.TestCase):
         forbidden_response.status_code = 403
         forbidden_err = customerioForbiddenError("HTTP-error-code: 403", forbidden_response)
 
-        def side_effect(method, endpoint, params=None, path=None, **kwargs):
+        def side_effect(method, endpoint=None, params=None, path=None, **kwargs):
             if path == "campaigns":
                 raise forbidden_err
             # all other streams succeed
@@ -57,7 +57,7 @@ class TestDiscoverProbing(unittest.TestCase):
         bad_request_response.status_code = 400
         bad_request_err = customerioBadRequestError("HTTP-error-code: 400", bad_request_response)
 
-        def side_effect(method, endpoint, params=None, path=None, **kwargs):
+        def side_effect(method, endpoint=None, params=None, path=None, **kwargs):
             if path == "campaigns":
                 raise bad_request_err
 
@@ -88,7 +88,7 @@ class TestDiscoverProbing(unittest.TestCase):
         forbidden_response.status_code = 403
         forbidden_err = customerioForbiddenError("HTTP-error-code: 403", forbidden_response)
 
-        def side_effect(method, endpoint, params=None, path=None, **kwargs):
+        def side_effect(method, endpoint=None, params=None, path=None, **kwargs):
             if path == "esp/suppression/bounces":
                 raise forbidden_err
 
@@ -104,7 +104,7 @@ class TestDiscoverProbing(unittest.TestCase):
 
         restricted = {"campaigns", "broadcasts"}
 
-        def side_effect(method, endpoint, params=None, path=None, **kwargs):
+        def side_effect(method, endpoint=None, params=None, path=None, **kwargs):
             if path in restricted:
                 raise forbidden_err
 
@@ -136,7 +136,7 @@ class TestDiscoverProbing(unittest.TestCase):
         forbidden_response.status_code = 403
         forbidden_err = customerioForbiddenError("HTTP-error-code: 403", forbidden_response)
 
-        def side_effect(method, endpoint, params=None, path=None, **kwargs):
+        def side_effect(method, endpoint=None, params=None, path=None, **kwargs):
             if path == "customers/attributes" and method == "POST":
                 raise forbidden_err
 


### PR DESCRIPTION
# Description of change
This PR changes discovery/catalog generation to optionally probe each stream’s API endpoint and exclude streams from the generated Singer catalog when the endpoint returns permission-related errors, with added support for resolving templated stream paths (e.g., EPS suppression types).

[SAC-30779](https://qlik-dev.atlassian.net/browse/SAC-30779)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
